### PR TITLE
Add additional options

### DIFF
--- a/dkb.py
+++ b/dkb.py
@@ -448,6 +448,7 @@ if __name__ == '__main__':
         help="Store the raw CSV file instead of QIF")
     cli.add_argument("--debug", action="store_true")
     cli.add_argument("--quiet", action="store_true")
+    cli.add_argument("--pin", default=os.environ.get('DKB_PIN', ""))
 
     args = cli.parse_args()
     if not args.userid:
@@ -473,7 +474,7 @@ if __name__ == '__main__':
     if not args.output:
         cli.error("Please specify a valid output path")
 
-    pin = ""
+    pin = args.pin
     import os
     if os.isatty(0):
         while not pin.strip():

--- a/dkb.py
+++ b/dkb.py
@@ -447,6 +447,7 @@ if __name__ == '__main__':
     cli.add_argument("--raw", action="store_true",
         help="Store the raw CSV file instead of QIF")
     cli.add_argument("--debug", action="store_true")
+    cli.add_argument("--quiet", action="store_true")
 
     args = cli.parse_args()
     if not args.userid:
@@ -457,6 +458,8 @@ if __name__ == '__main__':
     level = logging.INFO
     if args.debug:
         level = logging.DEBUG
+    elif args.quiet:
+        level = logging.ERROR
     logging.basicConfig(level=level, format='%(message)s')
 
     def is_valid_date(date):


### PR DESCRIPTION
I added a `--quiet` parameter so that I can specify `/dev/stdout` as the output file and process the resulting `qif` data from the outside directly, e.g. sending it through a pipe.

Also, I added an option to specify the PIN either as a command line parameter or as an env variable.